### PR TITLE
🔒 consumer: allow binding to port 80 as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,18 +19,24 @@ RUN bun build --compile --minify --sourcemap \
   idp-status-monitoring-producer/src/bin/index.ts --outfile=producer
 
 FROM alpine:latest AS base-runtime
-RUN apk add --no-cache ca-certificates libstdc++ libgcc
+RUN apk add --no-cache ca-certificates libstdc++ libgcc libcap
 RUN addgroup -g 1001 -S bun && adduser -S bun -u 1001
-USER bun
 
 FROM base-runtime AS consumer
 COPY --from=build-consumer --chown=bun:bun /app/consumer /usr/local/bin/
+RUN setcap 'cap_net_bind_service=+ep' /usr/local/bin/consumer
+USER bun
 CMD ["consumer"]
 
 FROM base-runtime AS producer
 COPY --from=build-producer --chown=bun:bun /app/producer /usr/local/bin/
+RUN setcap 'cap_net_bind_service=+ep' /usr/local/bin/producer
+USER bun
 CMD ["producer"]
 
 FROM base-runtime AS monitoring
 COPY --from=build-consumer --chown=bun:bun /app/consumer /usr/local/bin/
 COPY --from=build-producer --chown=bun:bun /app/producer /usr/local/bin/
+RUN setcap 'cap_net_bind_service=+ep' /usr/local/bin/consumer && \
+    setcap 'cap_net_bind_service=+ep' /usr/local/bin/producer
+USER bun


### PR DESCRIPTION
<div align=center><img src="https://media0.giphy.com/media/v1.Y2lkPWVjMTJjNzA0MjZ1YWdvb3ZxcW1uNW54YzZhbnJtd2M5eGxiMTM2cmNkNzZnNXh2dyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/kPgA9uoviqldvu02xG/giphy.gif" /></div>

---

## Problem

The consumer binary runs as user `bun` (uid 1001) but tries to bind to port 80. On Linux, binding to ports below 1024 requires root privileges, causing an `EACCES` error at startup.

## Proposal

Install `libcap` in the base runtime image and use `setcap cap_net_bind_service=+ep` on each compiled binary in the final stages. This grants the specific capability needed to bind privileged ports without running the process as root. The `USER bun` directive is moved to after `setcap` in each stage since `setcap` must run as root.