### PR TITLE
🔊 Add consola logging with LOG_LEVEL, fetch tracing and Hono integration

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,6 +17,7 @@
       "dependencies": {
         "amqp-connection-manager": "5.0.0",
         "amqplib": "0.10.9",
+        "consola": "3.4.2",
         "uuid": "13.0.0",
         "zod": "4.3.6",
       },
@@ -30,6 +31,7 @@
         "@hono/zod-validator": "0.7.6",
         "amqp-connection-manager": "5.0.0",
         "amqplib": "0.10.9",
+        "consola": "3.4.2",
         "hono": "4.12.9",
         "uuid": "13.0.0",
         "zod": "4.3.6",
@@ -57,6 +59,8 @@
     "buffer-more-ints": ["buffer-more-ints@1.0.0", "", {}, "sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg=="],
 
     "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+
+    "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
 
     "hono": ["hono@4.12.9", "", {}, "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA=="],
 

--- a/examples/idp_cascading_failures/integration.test.ts
+++ b/examples/idp_cascading_failures/integration.test.ts
@@ -22,8 +22,8 @@ describe("IDP Cascading Failures: Tyranid Hive Fleet resilience testing", () => 
 
   test.serial("📨 Producer: Connected to RabbitMQ", async () => {
     const producerLogs = await env.getServiceLogs("producer");
-    expect(producerLogs).toContain("Connected!");
-    expect(producerLogs).toContain("assertQueue : monitoring-producer");
+    expect(producerLogs).toContain("Connected to RabbitMQ");
+    expect(producerLogs).toContain('Asserting queue "monitoring-producer"');
   });
 
   test.serial(

--- a/examples/idp_error_handling/integration.test.ts
+++ b/examples/idp_error_handling/integration.test.ts
@@ -22,8 +22,8 @@ describe("IDP Error Handling: Graceful handling of various error scenarios", () 
 
   test.serial("📨 Producer: Connected to RabbitMQ", async () => {
     const producerLogs = await env.getServiceLogs("producer");
-    expect(producerLogs).toContain("Connected!");
-    expect(producerLogs).toContain("assertQueue : monitoring-producer");
+    expect(producerLogs).toContain("Connected to RabbitMQ");
+    expect(producerLogs).toContain('Asserting queue "monitoring-producer"');
   });
 
   test.serial(

--- a/examples/idp_health_check_rpc/integration.test.ts
+++ b/examples/idp_health_check_rpc/integration.test.ts
@@ -21,8 +21,8 @@ describe("IDP Health Check RPC: End-to-end distributed health monitoring", () =>
 
   test.serial("📨 Producer: Connected to RabbitMQ", async () => {
     const producerLogs = await env.getServiceLogs("producer");
-    expect(producerLogs).toContain("Connected!");
-    expect(producerLogs).toContain("assertQueue : monitoring-producer");
+    expect(producerLogs).toContain("Connected to RabbitMQ");
+    expect(producerLogs).toContain('Asserting queue "monitoring-producer"');
   });
 
   test.serial(

--- a/examples/idp_resilience/integration.test.ts
+++ b/examples/idp_resilience/integration.test.ts
@@ -21,8 +21,8 @@ describe("IDP Resilience: RabbitMQ failure graceful degradation", () => {
 
   test.serial("📨 Producer: Connected to RabbitMQ", async () => {
     const producerLogs = await env.getServiceLogs("producer");
-    expect(producerLogs).toContain("Connected!");
-    expect(producerLogs).toContain("assertQueue : monitoring-producer");
+    expect(producerLogs).toContain("Connected to RabbitMQ");
+    expect(producerLogs).toContain('Asserting queue "monitoring-producer"');
   });
 
   test.serial(

--- a/idp-status-monitoring-consumer/package.json
+++ b/idp-status-monitoring-consumer/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "amqp-connection-manager": "5.0.0",
     "amqplib": "0.10.9",
+    "consola": "3.4.2",
     "uuid": "13.0.0",
     "zod": "4.3.6"
   },

--- a/idp-status-monitoring-consumer/src/bin/index.ts
+++ b/idp-status-monitoring-consumer/src/bin/index.ts
@@ -3,11 +3,13 @@
 import { ConfigSchema } from "#src/config";
 import { createAmqpConnection, setupMessageConsumer } from "#src/rpc";
 import { createRoutes } from "#src/server";
-
-console.log("Starting idp-status-monitoring-consumer...");
+import consola from "consola";
 
 // Load configuration
 const config = await ConfigSchema.parseAsync(process.env);
+consola.level = config.LOG_LEVEL;
+
+consola.info("Starting idp-status-monitoring-consumer...");
 
 // Setup consumer
 const connection = await createAmqpConnection(config.AMQP_URL);
@@ -22,4 +24,4 @@ const server = Bun.serve({
   },
 });
 
-console.log(`Consumer started successfully! ${server.url}`);
+consola.info(`Consumer started successfully! ${server.url}`);

--- a/idp-status-monitoring-consumer/src/config/schema.ts
+++ b/idp-status-monitoring-consumer/src/config/schema.ts
@@ -64,6 +64,7 @@ export const ConfigSchema = z.object({
     .union([z.record(z.string(), z.string()), parseJsonRecord])
     .default({})
     .transform((val) => (typeof val === "string" ? JSON.parse(val) : val)),
+  LOG_LEVEL: z.coerce.number().default(3),
   PORT: z.coerce.number().default(80),
   QUEUE_CONSUMER_NAME: z.string().default("monitoring-consumer"),
   QUEUE_PRODUCER_NAME: z.string().default("monitoring-producer"),

--- a/idp-status-monitoring-consumer/src/rpc/index.ts
+++ b/idp-status-monitoring-consumer/src/rpc/index.ts
@@ -5,6 +5,28 @@ import amqp, {
   type AmqpConnectionManager,
   type Channel,
 } from "amqp-connection-manager";
+import consola from "consola";
+
+const elapsed = (start: number) => {
+  const delta = Date.now() - start;
+  return delta < 1000 ? `${delta}ms` : `${Math.round(delta / 1000)}s`;
+};
+
+const colorStatus = (status: number) => {
+  if (!process.stdout.isTTY) return `${status}`;
+  switch ((status / 100) | 0) {
+    case 5:
+      return `\x1b[31m${status}\x1b[0m`;
+    case 4:
+      return `\x1b[33m${status}\x1b[0m`;
+    case 3:
+      return `\x1b[36m${status}\x1b[0m`;
+    case 2:
+      return `\x1b[32m${status}\x1b[0m`;
+    default:
+      return `${status}`;
+  }
+};
 
 export async function checkIdpStatus(
   idpName: string,
@@ -25,33 +47,39 @@ export async function checkIdpStatus(
     "User-Agent": config.HTTP_USER_AGENT,
   });
 
+  const start = Date.now();
+  consola.log(`--> GET ${url}`);
+
   try {
     const response = await fetch(url, {
       signal: AbortSignal.timeout(config.HTTP_TIMEOUT),
       headers,
     });
+    consola.log(
+      `<-- GET ${url} ${colorStatus(response.status)} ${elapsed(start)}`,
+    );
     return response.status;
-  } catch {
+  } catch (err) {
+    consola.error(`xxx GET ${url} ${elapsed(start)}`, err);
     return 500;
   }
 }
 
 export async function createAmqpConnection(amqpUrl: string) {
-  console.log("connect to RabbitMQ");
+  consola.info("Connecting to RabbitMQ...");
 
   const connection = await amqp.connect([amqpUrl]);
 
   connection.on("connect", function () {
-    console.log("Connected!");
+    consola.info("Connected to RabbitMQ");
   });
 
   connection.on("connectFailed", function (err) {
-    console.log(err);
-    console.log("Failed to connect!");
+    consola.error("Failed to connect to RabbitMQ", err);
   });
 
   connection.on("disconnect", function (err) {
-    console.log("Disconnected.", err);
+    consola.warn("Disconnected from RabbitMQ", err);
   });
 
   return connection;
@@ -63,12 +91,12 @@ export function setupMessageConsumer(
 ) {
   const { QUEUE_PRODUCER_NAME, MAP_FI_NAMES_TO_URL, HTTP_TIMEOUT } = config;
 
-  console.log(MAP_FI_NAMES_TO_URL);
-  console.log(`using proxy : "${process.env.HTTPS_PROXY}"`);
+  consola.info("IDP URL map:", MAP_FI_NAMES_TO_URL);
+  consola.debug(`Using proxy: "${process.env.HTTPS_PROXY}"`);
 
   const channel_wrapper = connection.createChannel({
     setup: (channel: Channel) => {
-      console.log(`assertQueue ${QUEUE_PRODUCER_NAME}`);
+      consola.info(`Asserting queue "${QUEUE_PRODUCER_NAME}"`);
 
       return channel.assertQueue(QUEUE_PRODUCER_NAME, { durable: true });
     },
@@ -78,7 +106,7 @@ export function setupMessageConsumer(
     try {
       // Validate message structure
       if (!message?.content || !message?.properties) {
-        console.error(
+        consola.error(
           "Malformed message received: missing content or properties",
         );
         channel_wrapper.nack(message, false, false);
@@ -87,7 +115,7 @@ export function setupMessageConsumer(
 
       const { correlationId, replyTo } = message.properties;
       if (!correlationId || !replyTo) {
-        console.error(
+        consola.error(
           "Message missing required properties (correlationId or replyTo)",
         );
         channel_wrapper.nack(message, false, false);
@@ -95,11 +123,13 @@ export function setupMessageConsumer(
       }
 
       const idp = message.content.toString("utf8");
-      console.log(`received message : ${idp}`);
+      consola.debug(
+        `Received message: ${idp} (correlationId: ${correlationId})`,
+      );
 
       const status = await checkIdpStatus(idp, config);
 
-      console.log(`status : ${status}`);
+      consola.debug(`Status for ${idp}: ${status}`);
 
       const options = {
         correlationId,
@@ -110,7 +140,7 @@ export function setupMessageConsumer(
       channel_wrapper.sendToQueue(replyTo, JSON.stringify({ status }), options);
       channel_wrapper.ack(message);
     } catch (err) {
-      console.error("Error processing message:", err);
+      consola.error("Error processing message:", err);
       // Don't requeue on processing errors
       channel_wrapper.nack(message, false, false);
     }

--- a/idp-status-monitoring-consumer/src/server/routes.ts
+++ b/idp-status-monitoring-consumer/src/server/routes.ts
@@ -1,19 +1,59 @@
 //
 
+import type { MaybePromise } from "bun";
+import consola from "consola";
+
+type BunCallback = (req: Bun.BunRequest) => MaybePromise<Response>;
+
+const elapsed = (start: number) => {
+  const delta = Date.now() - start;
+  return delta < 1000 ? `${delta}ms` : `${Math.round(delta / 1000)}s`;
+};
+
+const colorStatus = (status: number) => {
+  if (!process.stdout.isTTY) return `${status}`;
+  switch ((status / 100) | 0) {
+    case 5:
+      return `\x1b[31m${status}\x1b[0m`;
+    case 4:
+      return `\x1b[33m${status}\x1b[0m`;
+    case 3:
+      return `\x1b[36m${status}\x1b[0m`;
+    case 2:
+      return `\x1b[32m${status}\x1b[0m`;
+    default:
+      return `${status}`;
+  }
+};
+
+const handler = (cb: BunCallback): BunCallback => {
+  return async (req: Bun.BunRequest) => {
+    const { pathname } = new URL(req.url);
+    const start = Date.now();
+    consola.log(`--> ${req.method} ${pathname}`);
+    const res = await cb(req);
+    consola.log(
+      `<-- ${req.method} ${pathname} ${colorStatus(res.status)} ${elapsed(start)}`,
+    );
+    return res;
+  };
+};
+
 export function createRoutes(getConnectionStatus: () => boolean) {
   return {
-    "/health/live": () => Response.json({ status: "alive" }),
+    "/health/live": handler(() => Response.json({ status: "alive" })),
 
-    "/health/startup": () => Response.json({ status: "started" }),
+    "/health/startup": handler(() => Response.json({ status: "started" })),
 
-    "/health": () =>
+    "/health": handler(() =>
       Response.json({
         status: "ok",
         uptime: process.uptime(),
         timestamp: new Date().toISOString(),
       }),
+    ),
 
-    "/health/ready": () => {
+    "/health/ready": handler(() => {
       const isConnected = getConnectionStatus();
       return Response.json(
         {
@@ -22,6 +62,6 @@ export function createRoutes(getConnectionStatus: () => boolean) {
         },
         { status: isConnected ? 200 : 503 },
       );
-    },
+    }),
   };
 }

--- a/idp-status-monitoring-producer/package.json
+++ b/idp-status-monitoring-producer/package.json
@@ -9,6 +9,7 @@
     "@hono/zod-validator": "0.7.6",
     "amqp-connection-manager": "5.0.0",
     "amqplib": "0.10.9",
+    "consola": "3.4.2",
     "hono": "4.12.9",
     "uuid": "13.0.0",
     "zod": "4.3.6"

--- a/idp-status-monitoring-producer/src/bin/index.ts
+++ b/idp-status-monitoring-producer/src/bin/index.ts
@@ -3,18 +3,22 @@
 import { ConfigSchema } from "#src/config";
 import { createAmqpConnection, setupRpcProducer } from "#src/rpc";
 import { router } from "#src/server";
+import consola from "consola";
 import { Hono } from "hono";
+import { logger } from "hono/logger";
 import type { ServerContext } from "../server/context";
 
 //
 
 const config = await ConfigSchema.parseAsync(process.env);
+consola.level = config.LOG_LEVEL;
 const connection = await createAmqpConnection(config.AMQP_URL);
 const channelWrapper = setupRpcProducer(connection, config);
 
 //
 
 const app = new Hono<ServerContext>()
+  .use(logger((str) => consola.log(str)))
   .use((context, next) => {
     Object.assign(context.env, config);
     context.set("channelWrapper", channelWrapper);

--- a/idp-status-monitoring-producer/src/config/schema.ts
+++ b/idp-status-monitoring-producer/src/config/schema.ts
@@ -30,6 +30,7 @@ export const ConfigSchema = z.object({
   AMQP_URL: z.url().default("amqp://guest:guest@rabbitmq:5672"),
   HTTP_TIMEOUT: z.coerce.number().default(5_000),
   IDP_URLS: parseJsonArray,
+  LOG_LEVEL: z.coerce.number().default(3),
   PORT: z.coerce.number().default(80),
   QUEUE_CONSUMER_NAME: z.string().default("monitoring-consumer"),
   QUEUE_PRODUCER_NAME: z.string().default("monitoring-producer"),

--- a/idp-status-monitoring-producer/src/rpc/index.ts
+++ b/idp-status-monitoring-producer/src/rpc/index.ts
@@ -5,23 +5,23 @@ import amqp, {
   type AmqpConnectionManager,
   type Channel,
 } from "amqp-connection-manager";
+import consola from "consola";
 
 export async function createAmqpConnection(amqpUrl: string) {
-  console.log("connect to RabbitMQ");
+  consola.info("Connecting to RabbitMQ...");
 
   const connection = await amqp.connect([amqpUrl]);
 
   connection.on("connect", function () {
-    console.log("Connected!");
+    consola.info("Connected to RabbitMQ");
   });
 
   connection.on("connectFailed", function (err) {
-    console.log(err);
-    console.log("Failed to connect!");
+    consola.error("Failed to connect to RabbitMQ", err);
   });
 
   connection.on("disconnect", function (err) {
-    console.log("Disconnected.", err);
+    consola.warn("Disconnected from RabbitMQ", err);
   });
 
   return connection;
@@ -35,8 +35,8 @@ export function setupRpcProducer(
 
   const channel_wrapper = connection.createChannel({
     setup: (channel: Channel) => {
-      console.log(`assertQueue : ${QUEUE_PRODUCER_NAME}`);
-      console.log(`assertQueue : ${QUEUE_CONSUMER_NAME}`);
+      consola.info(`Asserting queue "${QUEUE_PRODUCER_NAME}"`);
+      consola.info(`Asserting queue "${QUEUE_CONSUMER_NAME}"`);
 
       return Promise.all([
         channel.assertQueue(QUEUE_PRODUCER_NAME, { durable: true }),
@@ -50,7 +50,7 @@ export function setupRpcProducer(
     try {
       // Validate message structure
       if (!message?.content || !message?.properties) {
-        console.error(
+        consola.error(
           "Malformed message received: missing content or properties",
         );
         channel_wrapper.nack(message, false, false);
@@ -59,18 +59,18 @@ export function setupRpcProducer(
 
       const { correlationId } = message.properties;
       if (!correlationId) {
-        console.error("Message missing required correlationId property");
+        consola.error("Message missing required correlationId property");
         channel_wrapper.nack(message, false, false);
         return;
       }
 
       const content = message.content.toString("utf8");
-      console.log(`received message : ${correlationId} - ${content}`);
+      consola.debug(`Received message: ${correlationId} - ${content}`);
 
       channel_wrapper.emit(correlationId, content);
       channel_wrapper.ack(message);
     } catch (err) {
-      console.error("Error processing message:", err);
+      consola.error("Error processing message:", err);
       // Don't requeue on processing errors
       channel_wrapper.nack(message, false, false);
     }

--- a/idp-status-monitoring-producer/src/server/router.ts
+++ b/idp-status-monitoring-producer/src/server/router.ts
@@ -1,8 +1,8 @@
 //
 
 import { zValidator } from "@hono/zod-validator";
+import consola from "consola";
 import { Hono } from "hono";
-import { logger } from "hono/logger";
 import type { StatusCode } from "hono/utils/http-status";
 import { v4 as uuid } from "uuid";
 import z from "zod";
@@ -10,12 +10,32 @@ import type { ServerContext } from "./context";
 
 //
 
+const elapsed = (start: number) => {
+  const delta = Date.now() - start;
+  return delta < 1000 ? `${delta}ms` : `${Math.round(delta / 1000)}s`;
+};
+
+const colorStatus = (status: number) => {
+  if (!process.stdout.isTTY) return `${status}`;
+  switch ((status / 100) | 0) {
+    case 5:
+      return `\x1b[31m${status}\x1b[0m`;
+    case 4:
+      return `\x1b[33m${status}\x1b[0m`;
+    case 3:
+      return `\x1b[36m${status}\x1b[0m`;
+    case 2:
+      return `\x1b[32m${status}\x1b[0m`;
+    default:
+      return `${status}`;
+  }
+};
+
 const ParamsSchema = z.object({
   name: z.string().min(1),
 });
 
 export const router = new Hono<ServerContext>()
-  .use(logger())
   .get("/", ({ text }) => {
     return text("ok");
   })
@@ -23,15 +43,21 @@ export const router = new Hono<ServerContext>()
     const { HTTP_TIMEOUT, IDP_URLS } = env;
 
     const requests = IDP_URLS.map(async (url) => {
+      const start = Date.now();
+      consola.log(`--> GET ${url}`);
       try {
         const response = await fetch(url, {
           signal: AbortSignal.timeout(HTTP_TIMEOUT),
         });
+        consola.log(
+          `<-- GET ${url} ${colorStatus(response.status)} ${elapsed(start)}`,
+        );
         return {
           status: response.status,
           url,
         };
       } catch (e) {
+        consola.warn(`xxx GET ${url} ${elapsed(start)}`, e);
         return {
           status: 0,
           url,


### PR DESCRIPTION
<div align=center><img src="https://media3.giphy.com/media/v1.Y2lkPWVjMTJjNzA0NHFhangxcDJmNjg1MGpmNG40Njl1ajdlNTF5cW82c2oyNWdvZmVrZCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/v2Yk3HxROMAQ2AB7Vh/giphy.gif" /></div>

---

## Problem

All logging used bare `console.*` calls with no level control and no visibility into outgoing fetch requests. There was no way to silence or amplify logs at runtime, and external HTTP calls were completely invisible in logs.

## Proposal

Introduce `consola` in both packages with a `LOG_LEVEL` env var (default `3`/info, `4` for debug, `0` to silence). Replace all `console.*` calls with levelled consola equivalents. Add Hono-inspired `-->` / `<--` / `xxx` fetch tracing with elapsed time and colored HTTP status codes to all outgoing requests. Wire Hono's `logger()` middleware to `consola.log` so HTTP access logs respect `LOG_LEVEL`. Apply the same logging wrapper to the Bun health-check server routes.
