### PR TITLE
🏗️ consumer: introduce ServerContext to decouple server from AMQP startup

### DIFF
--- a/idp-status-monitoring-consumer/src/bin/index.ts
+++ b/idp-status-monitoring-consumer/src/bin/index.ts
@@ -2,26 +2,29 @@
 
 import { ConfigSchema } from "#src/config";
 import { createAmqpConnection, setupMessageConsumer } from "#src/rpc";
-import { createRoutes } from "#src/server";
+import { createRoutes, type ServerContext } from "#src/server";
 import consola from "consola";
 
-// Load configuration
 const config = await ConfigSchema.parseAsync(process.env);
 consola.level = config.LOG_LEVEL;
 
 consola.info("Starting idp-status-monitoring-consumer...");
 
-// Setup consumer
-const connection = await createAmqpConnection(config.AMQP_URL);
-setupMessageConsumer(connection, config);
+const context: ServerContext = { connection: null, config };
 
-// Health check server for Kubernetes probes
 const server = Bun.serve({
   port: config.PORT,
-  routes: createRoutes(() => connection.isConnected(), config),
+  routes: createRoutes(context),
   fetch() {
     return new Response("Not Found", { status: 404 });
   },
 });
 
 consola.info(`Consumer started successfully! ${server.url}`);
+
+try {
+  context.connection = await createAmqpConnection(config.AMQP_URL);
+  setupMessageConsumer(context.connection, config);
+} catch (err) {
+  consola.error("Failed to connect to AMQP:", err);
+}

--- a/idp-status-monitoring-consumer/src/server/context.ts
+++ b/idp-status-monitoring-consumer/src/server/context.ts
@@ -1,0 +1,9 @@
+//
+
+import type { Config } from "#src/config";
+import type { AmqpConnectionManager } from "amqp-connection-manager";
+
+export interface ServerContext {
+  connection: AmqpConnectionManager | null;
+  config: Config;
+}

--- a/idp-status-monitoring-consumer/src/server/index.ts
+++ b/idp-status-monitoring-consumer/src/server/index.ts
@@ -1,3 +1,4 @@
 //
 
+export * from "./context";
 export * from "./routes";

--- a/idp-status-monitoring-consumer/src/server/routes.test.ts
+++ b/idp-status-monitoring-consumer/src/server/routes.test.ts
@@ -1,4 +1,7 @@
+import type { Config } from "#src/config";
+import type { AmqpConnectionManager } from "amqp-connection-manager";
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import type { ServerContext } from "./context";
 import { createRoutes } from "./routes";
 
 describe("GET /health routes", () => {
@@ -169,26 +172,28 @@ describe("GET /health/idps", () => {
 
 //
 
+const defaultConfig = {
+  MAP_FI_NAMES_TO_URL: {},
+  HTTP_TIMEOUT: 5000,
+  HTTP_ACCEPT: "*/*",
+  HTTP_USER_AGENT: "test-agent",
+};
+
 function createTestServer({
   isConnected = true,
-  config = {
-    MAP_FI_NAMES_TO_URL: {},
-    HTTP_TIMEOUT: 5000,
-    HTTP_ACCEPT: "*/*",
-    HTTP_USER_AGENT: "test-agent",
-  },
+  config = {},
 }: {
   isConnected?: boolean;
-  config?: {
-    MAP_FI_NAMES_TO_URL: Record<string, string>;
-    HTTP_TIMEOUT: number;
-    HTTP_ACCEPT: string;
-    HTTP_USER_AGENT: string;
-  };
+  config?: Partial<typeof defaultConfig>;
 } = {}) {
+  const mergedConfig = { ...defaultConfig, ...config } as unknown as Config;
+  const connection = isConnected
+    ? ({ isConnected: () => true } as unknown as AmqpConnectionManager)
+    : null;
+  const context: ServerContext = { connection, config: mergedConfig };
   return Bun.serve({
     port: 0,
-    routes: createRoutes(() => isConnected, config),
+    routes: createRoutes(context),
     fetch() {
       return new Response("Not Found", { status: 404 });
     },

--- a/idp-status-monitoring-consumer/src/server/routes.ts
+++ b/idp-status-monitoring-consumer/src/server/routes.ts
@@ -2,6 +2,7 @@
 
 import type { MaybePromise } from "bun";
 import consola from "consola";
+import type { ServerContext } from "./context";
 
 type BunCallback = (req: Bun.BunRequest) => MaybePromise<Response>;
 
@@ -39,20 +40,7 @@ const handler = (cb: BunCallback): BunCallback => {
   };
 };
 
-export function createRoutes(
-  getConnectionStatus: () => boolean,
-  config: {
-    MAP_FI_NAMES_TO_URL: Record<string, string>;
-    HTTP_TIMEOUT: number;
-    HTTP_ACCEPT: string;
-    HTTP_USER_AGENT: string;
-  } = {
-    MAP_FI_NAMES_TO_URL: {},
-    HTTP_TIMEOUT: 5000,
-    HTTP_ACCEPT: "*/*",
-    HTTP_USER_AGENT: "",
-  },
-) {
+export function createRoutes(context: ServerContext) {
   return {
     "/health/live": handler(() => Response.json({ status: "alive" })),
 
@@ -67,7 +55,7 @@ export function createRoutes(
     ),
 
     "/health/ready": handler(() => {
-      const isConnected = getConnectionStatus();
+      const isConnected = context.connection?.isConnected() ?? false;
       return Response.json(
         {
           status: isConnected ? "ready" : "not ready",
@@ -78,28 +66,29 @@ export function createRoutes(
     }),
 
     "/health/idps": handler(async () => {
-      const requests = Object.entries(config.MAP_FI_NAMES_TO_URL).map(
-        async ([name, url]) => {
-          try {
-            const response = await fetch(url, {
-              signal: AbortSignal.timeout(config.HTTP_TIMEOUT),
-              headers: new Headers({
-                Accept: config.HTTP_ACCEPT,
-                "User-Agent": config.HTTP_USER_AGENT,
-              }),
-            });
-            return { name, url, status: response.status };
-          } catch (e) {
-            consola.warn(`xxx GET ${url}`, e);
-            return {
-              name,
-              url,
-              status: 0,
-              error: e instanceof Error ? e.message : String(e),
-            };
-          }
-        },
-      );
+      const { config } = context;
+      const requests = Object.entries(
+        config.MAP_FI_NAMES_TO_URL as Record<string, string>,
+      ).map(async ([name, url]) => {
+        try {
+          const response = await fetch(url, {
+            signal: AbortSignal.timeout(config.HTTP_TIMEOUT),
+            headers: new Headers({
+              Accept: config.HTTP_ACCEPT,
+              "User-Agent": config.HTTP_USER_AGENT,
+            }),
+          });
+          return { name, url, status: response.status };
+        } catch (e) {
+          consola.warn(`xxx GET ${url}`, e);
+          return {
+            name,
+            url,
+            status: 0,
+            error: e instanceof Error ? e.message : String(e),
+          };
+        }
+      });
       const responses = await Promise.all(requests);
       const successfuls = responses.filter(
         ({ status }) => status >= 200 && status < 400,


### PR DESCRIPTION


**Problem**

The HTTP server only started after AMQP connected, so Kubernetes liveness probes could not reach the pod during connection delays, causing unnecessary restart loops.

**Proposal**

Introduce a mutable ServerContext object (connection, config) passed to createRoutes. The server starts immediately with connection: null; route handlers read context.connection lazily at request time, so /health/ready naturally returns 503 until AMQP connects without any extra logic."