### PR TITLE
🩺 consumer: adopt Kubernetes standard health endpoint paths

### DIFF
--- a/examples/idp_cascading_failures/compose.yaml
+++ b/examples/idp_cascading_failures/compose.yaml
@@ -111,7 +111,7 @@ services:
           "--no-verbose",
           "--tries=1",
           "--spider",
-          "http://127.0.0.1/health/ready",
+          "http://127.0.0.1/readyz",
         ]
       interval: 5s
       timeout: 3s

--- a/examples/idp_error_handling/compose.yaml
+++ b/examples/idp_error_handling/compose.yaml
@@ -109,7 +109,7 @@ services:
           "--no-verbose",
           "--tries=1",
           "--spider",
-          "http://127.0.0.1/health/ready",
+          "http://127.0.0.1/readyz",
         ]
       interval: 5s
       timeout: 3s

--- a/examples/idp_health_check_rpc/compose.yaml
+++ b/examples/idp_health_check_rpc/compose.yaml
@@ -91,7 +91,7 @@ services:
           "--no-verbose",
           "--tries=1",
           "--spider",
-          "http://127.0.0.1/health/ready",
+          "http://127.0.0.1/readyz",
         ]
       interval: 5s
       timeout: 3s

--- a/examples/idp_proxy_middleware/compose.yaml
+++ b/examples/idp_proxy_middleware/compose.yaml
@@ -126,7 +126,7 @@ services:
           "--no-verbose",
           "--tries=1",
           "--spider",
-          "http://127.0.0.1/health/ready",
+          "http://127.0.0.1/readyz",
         ]
       interval: 5s
       timeout: 3s

--- a/examples/idp_resilience/compose.yaml
+++ b/examples/idp_resilience/compose.yaml
@@ -92,7 +92,7 @@ services:
           "--no-verbose",
           "--tries=1",
           "--spider",
-          "http://127.0.0.1/health/ready",
+          "http://127.0.0.1/readyz",
         ]
       interval: 5s
       timeout: 3s

--- a/idp-status-monitoring-consumer/src/server/routes.test.ts
+++ b/idp-status-monitoring-consumer/src/server/routes.test.ts
@@ -4,10 +4,10 @@ import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import type { ServerContext } from "./context";
 import { createRoutes } from "./routes";
 
-describe("GET /health routes", () => {
-  it("GET /health/live returns 200 with alive status", async () => {
+describe("GET health routes", () => {
+  it("GET /livez returns 200 with alive status", async () => {
     using server = createTestServer();
-    const res = await fetch(`${server.url}/health/live`);
+    const res = await fetch(`${server.url}/livez`);
 
     expect(res.status).toBe(200);
     await expect(res.json()).resolves.toMatchInlineSnapshot(`
@@ -17,9 +17,9 @@ describe("GET /health routes", () => {
     `);
   });
 
-  it("GET /health/startup returns 200 with started status", async () => {
+  it("GET /startupz returns 200 with started status", async () => {
     using server = createTestServer();
-    const res = await fetch(`${server.url}/health/startup`);
+    const res = await fetch(`${server.url}/startupz`);
 
     expect(res.status).toBe(200);
     await expect(res.json()).resolves.toMatchInlineSnapshot(`
@@ -29,9 +29,9 @@ describe("GET /health routes", () => {
     `);
   });
 
-  it("GET /health returns 200 with health info", async () => {
+  it("GET /healthz returns 200 with health info", async () => {
     using server = createTestServer();
-    const res = await fetch(`${server.url}/health`);
+    const res = await fetch(`${server.url}/healthz`);
 
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
@@ -44,9 +44,9 @@ describe("GET /health routes", () => {
     expect(typeof body.timestamp).toBe("string");
   });
 
-  it("GET /health/ready returns 200 when connected", async () => {
+  it("GET /readyz returns 200 when connected", async () => {
     using server = createTestServer();
-    const res = await fetch(`${server.url}/health/ready`);
+    const res = await fetch(`${server.url}/readyz`);
 
     expect(res.status).toBe(200);
     await expect(res.json()).resolves.toMatchInlineSnapshot(`
@@ -57,9 +57,9 @@ describe("GET /health routes", () => {
     `);
   });
 
-  it("GET /health/ready returns 503 when disconnected", async () => {
+  it("GET /readyz returns 503 when disconnected", async () => {
     using server = createTestServer({ isConnected: false });
-    const res = await fetch(`${server.url}/health/ready`);
+    const res = await fetch(`${server.url}/readyz`);
 
     expect(res.status).toBe(503);
     await expect(res.json()).resolves.toMatchInlineSnapshot(`
@@ -78,7 +78,7 @@ describe("GET /health routes", () => {
   });
 });
 
-describe("GET /health/idps", () => {
+describe("GET /readyz/idps", () => {
   let fetchSpy: ReturnType<typeof spyOn>;
   let originalFetch: typeof global.fetch;
 
@@ -93,7 +93,7 @@ describe("GET /health/idps", () => {
 
   it("returns 200 with empty lists when no IDPs configured", async () => {
     using server = createTestServer();
-    const res = await originalFetch(`${server.url}/health/idps`);
+    const res = await originalFetch(`${server.url}/readyz/idps`);
 
     expect(res.status).toBe(200);
     await expect(res.json()).resolves.toMatchInlineSnapshot(`
@@ -115,7 +115,7 @@ describe("GET /health/idps", () => {
         HTTP_USER_AGENT: "test-agent",
       },
     });
-    const res = await originalFetch(`${server.url}/health/idps`);
+    const res = await originalFetch(`${server.url}/readyz/idps`);
 
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
@@ -142,7 +142,7 @@ describe("GET /health/idps", () => {
         HTTP_USER_AGENT: "test-agent",
       },
     });
-    const res = await originalFetch(`${server.url}/health/idps`);
+    const res = await originalFetch(`${server.url}/readyz/idps`);
 
     expect(res.status).toBe(200);
     const body = (await res.json()) as {

--- a/idp-status-monitoring-consumer/src/server/routes.ts
+++ b/idp-status-monitoring-consumer/src/server/routes.ts
@@ -42,11 +42,11 @@ const handler = (cb: BunCallback): BunCallback => {
 
 export function createRoutes(context: ServerContext) {
   return {
-    "/health/live": handler(() => Response.json({ status: "alive" })),
+    "/livez": handler(() => Response.json({ status: "alive" })),
 
-    "/health/startup": handler(() => Response.json({ status: "started" })),
+    "/startupz": handler(() => Response.json({ status: "started" })),
 
-    "/health": handler(() =>
+    "/healthz": handler(() =>
       Response.json({
         status: "ok",
         uptime: process.uptime(),
@@ -54,7 +54,7 @@ export function createRoutes(context: ServerContext) {
       }),
     ),
 
-    "/health/ready": handler(() => {
+    "/readyz": handler(() => {
       const isConnected = context.connection?.isConnected() ?? false;
       return Response.json(
         {
@@ -65,7 +65,7 @@ export function createRoutes(context: ServerContext) {
       );
     }),
 
-    "/health/idps": handler(async () => {
+    "/readyz/idps": handler(async () => {
       const { config } = context;
       const requests = Object.entries(
         config.MAP_FI_NAMES_TO_URL as Record<string, string>,


### PR DESCRIPTION
<div align=center><img src="https://media1.giphy.com/media/v1.Y2lkPWVjMTJjNzA0NDZ3bjc5bmZod3FrdXNuYmg2NGNxYXluMmR2emRlenN6bGt6Mm9vaiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/dBUGEhrhLNcFku19uo/giphy.gif" /></div>

---

## Problem

Custom `/health/*` paths don't match the Kubernetes API server convention, requiring non-standard probe configuration in every deployment manifest.

## Proposal

Rename endpoints to the k8s standard suffixes so probe paths work out of the box:

| Before | After |
|--------|-------|
| `/health/live` | `/livez` |
| `/health/startup` | `/startupz` |
| `/health` | `/healthz` |
| `/health/ready` | `/readyz` |
| `/health/idps` | `/readyz/idps` |