### PR TITLE
🩺 producer: add Kubernetes standard health endpoints

### DIFF
--- a/idp-status-monitoring-producer/src/bin/index.ts
+++ b/idp-status-monitoring-producer/src/bin/index.ts
@@ -22,6 +22,7 @@ const app = new Hono<ServerContext>()
   .use((context, next) => {
     Object.assign(context.env, config);
     context.set("channelWrapper", channelWrapper);
+    context.set("connection", connection);
     return next();
   })
   .route("", router);

--- a/idp-status-monitoring-producer/src/server/context.ts
+++ b/idp-status-monitoring-producer/src/server/context.ts
@@ -1,7 +1,10 @@
 //
 
 import type { Config } from "#src/config";
-import type { ChannelWrapper } from "amqp-connection-manager";
+import type {
+  AmqpConnectionManager,
+  ChannelWrapper,
+} from "amqp-connection-manager";
 import type { Env } from "hono";
 
 //
@@ -10,5 +13,6 @@ export interface ServerContext extends Env {
   Bindings: Config;
   Variables: {
     channelWrapper: ChannelWrapper;
+    connection: AmqpConnectionManager | null;
   };
 }

--- a/idp-status-monitoring-producer/src/server/router.test.ts
+++ b/idp-status-monitoring-producer/src/server/router.test.ts
@@ -1,5 +1,80 @@
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import { Hono } from "hono";
+import type { ServerContext } from "./context";
 import { router } from "./router";
+
+const makeApp = (connection: { isConnected: () => boolean } | null = null) =>
+  new Hono<ServerContext>()
+    .use((c, next) => {
+      c.set("connection", connection as any);
+      return next();
+    })
+    .route("", router);
+
+describe("GET /livez", () => {
+  it("should return 200 with alive status", async () => {
+    const res = await router.fetch(new Request("http://localhost/livez"), {});
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchInlineSnapshot(`
+      {
+        "status": "alive",
+      }
+    `);
+  });
+});
+
+describe("GET /healthz", () => {
+  it("should return 200 with uptime and timestamp", async () => {
+    const res = await router.fetch(new Request("http://localhost/healthz"), {});
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      status: string;
+      uptime: number;
+      timestamp: string;
+    };
+    expect(body.status).toBe("ok");
+    expect(typeof body.uptime).toBe("number");
+    expect(typeof body.timestamp).toBe("string");
+  });
+});
+
+describe("GET /readyz", () => {
+  it("should return 200 when AMQP is connected", async () => {
+    const app = makeApp({ isConnected: () => true });
+    const res = await app.fetch(new Request("http://localhost/readyz"), {});
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchInlineSnapshot(`
+      {
+        "amqp": "connected",
+        "status": "ready",
+      }
+    `);
+  });
+
+  it("should return 503 when AMQP is disconnected", async () => {
+    const app = makeApp({ isConnected: () => false });
+    const res = await app.fetch(new Request("http://localhost/readyz"), {});
+    expect(res.status).toBe(503);
+    await expect(res.json()).resolves.toMatchInlineSnapshot(`
+      {
+        "amqp": "disconnected",
+        "status": "not ready",
+      }
+    `);
+  });
+
+  it("should return 503 when connection is null", async () => {
+    const app = makeApp(null);
+    const res = await app.fetch(new Request("http://localhost/readyz"), {});
+    expect(res.status).toBe(503);
+    await expect(res.json()).resolves.toMatchInlineSnapshot(`
+      {
+        "amqp": "disconnected",
+        "status": "not ready",
+      }
+    `);
+  });
+});
 
 describe("GET /idp/internet - Aggregation logic", () => {
   let fetchSpy: any;

--- a/idp-status-monitoring-producer/src/server/router.ts
+++ b/idp-status-monitoring-producer/src/server/router.ts
@@ -39,6 +39,24 @@ export const router = new Hono<ServerContext>()
   .get("/", ({ text }) => {
     return text("ok");
   })
+  .get("/livez", ({ json }) => json({ status: "alive" }))
+  .get("/healthz", ({ json }) =>
+    json({
+      status: "ok",
+      uptime: process.uptime(),
+      timestamp: new Date().toISOString(),
+    }),
+  )
+  .get("/readyz", ({ var: { connection }, json }) => {
+    const isConnected = connection?.isConnected() ?? false;
+    return json(
+      {
+        status: isConnected ? "ready" : "not ready",
+        amqp: isConnected ? "connected" : "disconnected",
+      },
+      isConnected ? 200 : 503,
+    );
+  })
   .get("/idp/internet", async ({ env, json, status }) => {
     const { HTTP_TIMEOUT, IDP_URLS } = env;
 


### PR DESCRIPTION
<div align=center><img src="https://media2.giphy.com/media/v1.Y2lkPWVjMTJjNzA0M2o3bTdqYmFpbnJ6cjhvZjY1czl1MnY5aHRrNmQ0NHdnMm95MTgzeSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/lrg1gSNNh2aKv6fi8j/giphy.gif" /></div>

---

## Problem

The producer had no standard Kubernetes health endpoints, making it opaque to liveness/readiness probes. AMQP connectivity was unobservable without issuing a full IdP request, and there was no lightweight way for the orchestrator to distinguish a starting pod from a broken one.

## Proposal

Add `/livez`, `/healthz`, and `/readyz` to the Hono router, matching the contract already in place on the consumer. `/readyz` checks `AmqpConnectionManager.isConnected()` and returns 503 when disconnected. `connection` is added to `ServerContext.Variables` so the router can access it without coupling to the bin entrypoint. All three endpoints are covered with inline snapshot tests.