### PR TITLE
⚡️ producer: stream /idp/internet results as they arrive

### DIFF
--- a/examples/idp_cascading_failures/integration.test.ts
+++ b/examples/idp_cascading_failures/integration.test.ts
@@ -64,31 +64,31 @@ describe("IDP Cascading Failures: Tyranid Hive Fleet resilience testing", () => 
     async () => {
       const result = await env.execInService(
         "test_runner",
-        "curl -s -w '%{http_code}' http://producer/idp/internet",
+        "curl -s http://producer/idp/internet",
       );
-      const statusCode = result.output.match(/'(\d+)'/)?.[1];
-      expect(statusCode).toBe("200");
-
-      const jsonOutput = result.output.replace(/'200'/, "").trim();
-      const responseJson = JSON.parse(jsonOutput);
-      expect(responseJson).toMatchInlineSnapshot(`
-        {
-          "successfuls": [
-            {
-              "status": 200,
-              "url": "http://auth.kraken.tyranids",
-            },
-            {
-              "status": 200,
-              "url": "http://auth.leviathan.tyranids",
-            },
-            {
-              "status": 200,
-              "url": "http://auth.behemoth.tyranids",
-            },
-          ],
-          "unsucessfuls": [],
-        }
+      const lines = result.output
+        .trim()
+        .split("\n")
+        .filter(Boolean)
+        .map((line: string) => JSON.parse(line))
+        .sort((a: { url: string }, b: { url: string }) =>
+          a.url.localeCompare(b.url),
+        );
+      expect(lines).toMatchInlineSnapshot(`
+        [
+          {
+            "status": 200,
+            "url": "http://auth.behemoth.tyranids",
+          },
+          {
+            "status": 200,
+            "url": "http://auth.kraken.tyranids",
+          },
+          {
+            "status": 200,
+            "url": "http://auth.leviathan.tyranids",
+          },
+        ]
       `);
     },
   );
@@ -113,31 +113,42 @@ describe("IDP Cascading Failures: Tyranid Hive Fleet resilience testing", () => 
     await env.stopService("auth.leviathan.tyranids");
   });
 
-  test.serial(
-    "📊 GET /idp/internet - 1/3 Hive Fleet operational (503)",
-    async () => {
-      const result = await env.execInService(
-        "test_runner",
-        "curl -s -w '%{http_code}' http://producer/idp/internet",
-      );
-      const statusCode = result.output.match(/'(\d+)'/)?.[1];
-      expect(statusCode).toBe("503");
-    },
-  );
+  test.serial("📊 GET /idp/internet - 1/3 Hive Fleet operational", async () => {
+    const result = await env.execInService(
+      "test_runner",
+      "curl -s http://producer/idp/internet",
+    );
+    const lines = result.output
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line: string) => JSON.parse(line));
+    const failures = lines.filter(
+      (e: { status: number }) => e.status === 0 || e.status >= 400,
+    );
+    expect(failures.length).toBe(2);
+  });
 
   test.serial("🦑 Stop Kraken Hive Fleet", async () => {
     await env.stopService("auth.kraken.tyranids");
   });
 
   test.serial(
-    "📊 GET /idp/internet - 0/3 Hive Fleets operational (503)",
+    "📊 GET /idp/internet - 0/3 Hive Fleets operational",
     async () => {
       const result = await env.execInService(
         "test_runner",
-        "curl -s -w '%{http_code}' http://producer/idp/internet",
+        "curl -s http://producer/idp/internet",
       );
-      const statusCode = result.output.match(/'(\d+)'/)?.[1];
-      expect(statusCode).toBe("503");
+      const lines = result.output
+        .trim()
+        .split("\n")
+        .filter(Boolean)
+        .map((line: string) => JSON.parse(line));
+      const failures = lines.filter(
+        (e: { status: number }) => e.status === 0 || e.status >= 400,
+      );
+      expect(failures.length).toBe(3);
     },
   );
 

--- a/examples/idp_error_handling/integration.test.ts
+++ b/examples/idp_error_handling/integration.test.ts
@@ -60,17 +60,25 @@ describe("IDP Error Handling: Graceful handling of various error scenarios", () 
   );
 
   test.serial(
-    "📊 GET /idp/internet - Aggregated health includes errors",
+    "📊 GET /idp/internet - Streamed health includes errors",
     async () => {
       const result = await env.execInService(
         "test_runner",
         "curl -s http://producer/idp/internet",
       );
-      const data = JSON.parse(result.output);
-      expect(data.successfuls).toBeDefined();
-      expect(data.unsucessfuls).toBeDefined();
-      expect(data.successfuls.length).toBeGreaterThan(0);
-      expect(data.unsucessfuls.length).toBeGreaterThan(0);
+      const lines = result.output
+        .trim()
+        .split("\n")
+        .filter(Boolean)
+        .map((line: string) => JSON.parse(line));
+      const successes = lines.filter(
+        (e: { status: number }) => e.status >= 200 && e.status < 400,
+      );
+      const failures = lines.filter(
+        (e: { status: number }) => e.status === 0 || e.status >= 400,
+      );
+      expect(successes.length).toBeGreaterThan(0);
+      expect(failures.length).toBeGreaterThan(0);
     },
   );
 

--- a/examples/idp_health_check_rpc/integration.test.ts
+++ b/examples/idp_health_check_rpc/integration.test.ts
@@ -55,15 +55,18 @@ describe("IDP Health Check RPC: End-to-end distributed health monitoring", () =>
     expect(result.output).toBe("'404'");
   });
 
-  test.serial("📊 GET /idp/internet - Aggregated health check", async () => {
+  test.serial("📊 GET /idp/internet - Streamed health check", async () => {
     const result = await env.execInService(
       "test_runner",
       "curl -s http://producer/idp/internet",
     );
-    const data = JSON.parse(result.output);
-    expect(data.successfuls).toBeDefined();
-    expect(data.unsucessfuls).toBeDefined();
-    expect(data.successfuls.length).toBeGreaterThan(0);
+    const lines = result.output
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line: string) => JSON.parse(line));
+    expect(lines.length).toBeGreaterThan(0);
+    expect(lines.every((entry: { url: string }) => entry.url)).toBe(true);
   });
 
   test.serial(

--- a/examples/idp_proxy_middleware/integration.test.ts
+++ b/examples/idp_proxy_middleware/integration.test.ts
@@ -51,27 +51,31 @@ describe("IDP Monitoring via Proxy: Split-network architecture with internet and
   });
 
   test.serial(
-    "🌐 Producer: GET /idp/internet returns aggregated health from external IDPs",
+    "🌐 Producer: GET /idp/internet streams health from external IDPs",
     async () => {
       const result = await env.execInService(
         "test_runner",
         "curl -s http://producer/idp/internet",
       );
-      const data = JSON.parse(result.output);
-      expect(data).toMatchInlineSnapshot(`
-        {
-          "successfuls": [
-            {
-              "status": 200,
-              "url": "http://auth.olympia.ironwarriors",
-            },
-            {
-              "status": 200,
-              "url": "http://auth.medrengard.ironwarriors",
-            },
-          ],
-          "unsucessfuls": [],
-        }
+      const lines = result.output
+        .trim()
+        .split("\n")
+        .filter(Boolean)
+        .map((line: string) => JSON.parse(line))
+        .sort((a: { url: string }, b: { url: string }) =>
+          a.url.localeCompare(b.url),
+        );
+      expect(lines).toMatchInlineSnapshot(`
+        [
+          {
+            "status": 200,
+            "url": "http://auth.medrengard.ironwarriors",
+          },
+          {
+            "status": 200,
+            "url": "http://auth.olympia.ironwarriors",
+          },
+        ]
       `);
     },
   );

--- a/examples/idp_resilience/integration.test.ts
+++ b/examples/idp_resilience/integration.test.ts
@@ -72,27 +72,27 @@ describe("IDP Resilience: RabbitMQ failure graceful degradation", () => {
     async () => {
       const result = await env.execInService(
         "test_runner",
-        "curl -s -w '%{http_code}' http://producer/idp/internet",
+        "curl -s http://producer/idp/internet",
       );
-      const statusCode = result.output.match(/'(\d+)'/)?.[1];
-      expect(statusCode).toBe("200");
-
-      const jsonOutput = result.output.replace(/'200'/, "").trim();
-      const responseJson = JSON.parse(jsonOutput);
-      expect(responseJson).toMatchInlineSnapshot(`
-        {
-          "successfuls": [
-            {
-              "status": 200,
-              "url": "http://auth.macragge.ultramarines",
-            },
-            {
-              "status": 200,
-              "url": "http://auth.calth.ultramarines",
-            },
-          ],
-          "unsucessfuls": [],
-        }
+      const lines = result.output
+        .trim()
+        .split("\n")
+        .filter(Boolean)
+        .map((line: string) => JSON.parse(line))
+        .sort((a: { url: string }, b: { url: string }) =>
+          a.url.localeCompare(b.url),
+        );
+      expect(lines).toMatchInlineSnapshot(`
+        [
+          {
+            "status": 200,
+            "url": "http://auth.calth.ultramarines",
+          },
+          {
+            "status": 200,
+            "url": "http://auth.macragge.ultramarines",
+          },
+        ]
       `);
     },
   );

--- a/idp-status-monitoring-producer/src/server/router.test.ts
+++ b/idp-status-monitoring-producer/src/server/router.test.ts
@@ -76,7 +76,17 @@ describe("GET /readyz", () => {
   });
 });
 
-describe("GET /idp/internet - Aggregation logic", () => {
+const parseNDJSON = async (res: Response) => {
+  const text = await res.text();
+  return text
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line))
+    .sort((a, b) => a.url.localeCompare(b.url));
+};
+
+describe("GET /idp/internet - NDJSON streaming", () => {
   let fetchSpy: any;
 
   beforeEach(() => {
@@ -87,269 +97,93 @@ describe("GET /idp/internet - Aggregation logic", () => {
     fetchSpy.mockRestore();
   });
 
-  it("should return 200 when all IDP URLs are successful", async () => {
-    const mockUrls = ["https://idp1.test", "https://idp2.test"];
+  it("should stream one line per URL", async () => {
+    fetchSpy.mockResolvedValue({ status: 200 });
 
-    fetchSpy.mockResolvedValue({
-      status: 200,
-    });
-
-    const req = new Request("http://localhost/idp/internet", {
-      headers: { "Content-Type": "application/json" },
-    });
-
-    const res = await router.fetch(req, {
-      HTTP_TIMEOUT: 0,
-      IDP_URLS: mockUrls,
-    });
-
-    await expect(res.json()).resolves.toMatchInlineSnapshot(`
+    const res = await router.fetch(
+      new Request("http://localhost/idp/internet"),
       {
-        "successfuls": [
-          {
-            "status": 200,
-            "url": "https://idp1.test",
-          },
-          {
-            "status": 200,
-            "url": "https://idp2.test",
-          },
-        ],
-        "unsucessfuls": [],
-      }
-    `);
+        HTTP_TIMEOUT: 0,
+        IDP_URLS: ["https://idp1.test", "https://idp2.test"],
+      },
+    );
+
     expect(res.status).toBe(200);
-  });
-
-  it("should return 503 when more URLs fail than succeed", async () => {
-    const mockUrls = [
-      "https://idp1.test",
-      "https://idp2.test",
-      "https://idp3.test",
-    ];
-
-    fetchSpy
-      .mockResolvedValueOnce({ status: 200 })
-      .mockResolvedValueOnce({ status: 500 })
-      .mockResolvedValueOnce({ status: 404 });
-
-    const req = new Request("http://localhost/idp/internet");
-
-    const res = await router.fetch(req, {
-      HTTP_TIMEOUT: 0,
-      IDP_URLS: mockUrls,
-    });
-
-    await expect(res.json()).resolves.toMatchInlineSnapshot(`
-      {
-        "successfuls": [
-          {
-            "status": 200,
-            "url": "https://idp1.test",
-          },
-        ],
-        "unsucessfuls": [
-          {
-            "status": 500,
-            "url": "https://idp2.test",
-          },
-          {
-            "status": 404,
-            "url": "https://idp3.test",
-          },
-        ],
-      }
-    `);
-    expect(res.status).toBe(503);
-  });
-
-  it("should return 503 when all URLs fail", async () => {
-    const mockUrls = ["https://idp1.test", "https://idp2.test"];
-
-    fetchSpy.mockResolvedValue({
-      status: 500,
-    });
-
-    const req = new Request("http://localhost/idp/internet");
-
-    const res = await router.fetch(req, {
-      HTTP_TIMEOUT: 0,
-      IDP_URLS: mockUrls,
-    });
-
-    await expect(res.json()).resolves.toMatchInlineSnapshot(`
-      {
-        "successfuls": [],
-        "unsucessfuls": [
-          {
-            "status": 500,
-            "url": "https://idp1.test",
-          },
-          {
-            "status": 500,
-            "url": "https://idp2.test",
-          },
-        ],
-      }
-    `);
-    expect(res.status).toBe(503);
-  });
-
-  it("should return 503 when equal numbers succeed and fail", async () => {
-    const mockUrls = ["https://idp1.test", "https://idp2.test"];
-
-    fetchSpy
-      .mockResolvedValueOnce({ status: 200 })
-      .mockResolvedValueOnce({ status: 500 });
-
-    const req = new Request("http://localhost/idp/internet");
-
-    const res = await router.fetch(req, {
-      HTTP_TIMEOUT: 0,
-      IDP_URLS: mockUrls,
-    });
-
-    expect(res.status).toBe(503);
-    await expect(res.json()).resolves.toMatchInlineSnapshot(`
-      {
-        "successfuls": [
-          {
-            "status": 200,
-            "url": "https://idp1.test",
-          },
-        ],
-        "unsucessfuls": [
-          {
-            "status": 500,
-            "url": "https://idp2.test",
-          },
-        ],
-      }
+    await expect(parseNDJSON(res)).resolves.toMatchInlineSnapshot(`
+      [
+        {
+          "status": 200,
+          "url": "https://idp1.test",
+        },
+        {
+          "status": 200,
+          "url": "https://idp2.test",
+        },
+      ]
     `);
   });
 
-  it("should return 503 for empty IDP_URLS array", async () => {
-    const req = new Request("http://localhost/idp/internet");
-
-    const res = await router.fetch(req, {
-      IDP_URLS: [],
-    });
-
-    await expect(res.json()).resolves.toMatchInlineSnapshot(`
-      {
-        "successfuls": [],
-        "unsucessfuls": [],
-      }
-    `);
-    expect(res.status).toBe(503);
-  });
-
-  it("should return status 0 with error when fetch throws", async () => {
-    const mockUrls = ["https://idp1.test"];
-
+  it("should stream status 0 with error when fetch throws", async () => {
     fetchSpy.mockRejectedValue(new Error("Network failure"));
 
-    const req = new Request("http://localhost/idp/internet");
-
-    const res = await router.fetch(req, {
-      HTTP_TIMEOUT: 0,
-      IDP_URLS: mockUrls,
-    });
-
-    await expect(res.json()).resolves.toMatchInlineSnapshot(`
+    const res = await router.fetch(
+      new Request("http://localhost/idp/internet"),
       {
-        "successfuls": [],
-        "unsucessfuls": [
-          {
-            "error": "Network failure",
-            "status": 0,
-            "url": "https://idp1.test",
-          },
-        ],
-      }
+        HTTP_TIMEOUT: 0,
+        IDP_URLS: ["https://idp1.test"],
+      },
+    );
+
+    expect(res.status).toBe(200);
+    await expect(parseNDJSON(res)).resolves.toMatchInlineSnapshot(`
+      [
+        {
+          "error": "Network failure",
+          "status": 0,
+          "url": "https://idp1.test",
+        },
+      ]
     `);
-    expect(res.status).toBe(503);
   });
 
-  it("should handle mix of successful responses and fetch errors", async () => {
-    const mockUrls = ["https://idp1.test", "https://idp2.test"];
-
+  it("should stream mix of successes and errors", async () => {
     fetchSpy
       .mockResolvedValueOnce({ status: 200 })
       .mockRejectedValueOnce(new Error("Connection refused"));
 
-    const req = new Request("http://localhost/idp/internet");
-
-    const res = await router.fetch(req, {
-      HTTP_TIMEOUT: 0,
-      IDP_URLS: mockUrls,
-    });
-
-    await expect(res.json()).resolves.toMatchInlineSnapshot(`
+    const res = await router.fetch(
+      new Request("http://localhost/idp/internet"),
       {
-        "successfuls": [
-          {
-            "status": 200,
-            "url": "https://idp1.test",
-          },
-        ],
-        "unsucessfuls": [
-          {
-            "error": "Connection refused",
-            "status": 0,
-            "url": "https://idp2.test",
-          },
-        ],
-      }
+        HTTP_TIMEOUT: 0,
+        IDP_URLS: ["https://idp1.test", "https://idp2.test"],
+      },
+    );
+
+    expect(res.status).toBe(200);
+    await expect(parseNDJSON(res)).resolves.toMatchInlineSnapshot(`
+      [
+        {
+          "status": 200,
+          "url": "https://idp1.test",
+        },
+        {
+          "error": "Connection refused",
+          "status": 0,
+          "url": "https://idp2.test",
+        },
+      ]
     `);
-    expect(res.status).toBe(503);
   });
 
-  it("should correctly categorize different HTTP status codes", async () => {
-    const mockUrls = [
-      "https://idp1.test",
-      "https://idp2.test",
-      "https://idp3.test",
-      "https://idp4.test",
-    ];
-
-    fetchSpy
-      .mockResolvedValueOnce({ status: 200 })
-      .mockResolvedValueOnce({ status: 301 })
-      .mockResolvedValueOnce({ status: 404 })
-      .mockResolvedValueOnce({ status: 100 });
-
-    const req = new Request("http://localhost/idp/internet");
-
-    const res = await router.fetch(req, {
-      HTTP_TIMEOUT: 0,
-      IDP_URLS: mockUrls,
-    });
-
-    await expect(res.json()).resolves.toMatchInlineSnapshot(`
+  it("should return empty body for empty IDP_URLS", async () => {
+    const res = await router.fetch(
+      new Request("http://localhost/idp/internet"),
       {
-        "successfuls": [
-          {
-            "status": 200,
-            "url": "https://idp1.test",
-          },
-          {
-            "status": 301,
-            "url": "https://idp2.test",
-          },
-        ],
-        "unsucessfuls": [
-          {
-            "status": 404,
-            "url": "https://idp3.test",
-          },
-          {
-            "status": 100,
-            "url": "https://idp4.test",
-          },
-        ],
-      }
-    `);
-    expect(res.status).toBe(503);
+        IDP_URLS: [],
+      },
+    );
+
+    expect(res.status).toBe(200);
+    await expect(parseNDJSON(res)).resolves.toMatchInlineSnapshot(`[]`);
   });
 });

--- a/idp-status-monitoring-producer/src/server/router.ts
+++ b/idp-status-monitoring-producer/src/server/router.ts
@@ -3,6 +3,7 @@
 import { zValidator } from "@hono/zod-validator";
 import consola from "consola";
 import { Hono } from "hono";
+import { stream } from "hono/streaming";
 import type { StatusCode } from "hono/utils/http-status";
 import { v4 as uuid } from "uuid";
 import z from "zod";
@@ -57,47 +58,34 @@ export const router = new Hono<ServerContext>()
       isConnected ? 200 : 503,
     );
   })
-  .get("/idp/internet", async ({ env, json, status }) => {
-    const { HTTP_TIMEOUT, IDP_URLS } = env;
+  .get("/idp/internet", (c) => {
+    const { HTTP_TIMEOUT, IDP_URLS } = c.env;
 
-    const requests = IDP_URLS.map(async (url) => {
-      const start = Date.now();
-      consola.log(`--> GET ${url}`);
-      try {
-        const response = await fetch(url, {
-          signal: AbortSignal.timeout(HTTP_TIMEOUT),
-        });
-        consola.log(
-          `<-- GET ${url} ${colorStatus(response.status)} ${elapsed(start)}`,
-        );
-        return {
-          status: response.status,
-          url,
-        };
-      } catch (e) {
-        consola.warn(`xxx GET ${url} ${elapsed(start)}`, e);
-        return {
-          status: 0,
-          url,
-          error: e instanceof Error ? e.message : String(e),
-        };
-      }
-    });
-    const responses = await Promise.all(requests);
-
-    const successfuls = responses.filter(
-      (response) => response.status >= 200 && response.status < 400,
-    );
-
-    const unsucessfuls = responses.filter(
-      (response) => response.status < 200 || response.status >= 400,
-    );
-
-    status(unsucessfuls.length < successfuls.length ? 200 : 503);
-
-    return json({
-      successfuls,
-      unsucessfuls,
+    return stream(c, async (s) => {
+      await Promise.all(
+        IDP_URLS.map(async (url) => {
+          const start = Date.now();
+          consola.log(`--> GET ${url}`);
+          try {
+            const response = await fetch(url, {
+              signal: AbortSignal.timeout(HTTP_TIMEOUT),
+            });
+            consola.log(
+              `<-- GET ${url} ${colorStatus(response.status)} ${elapsed(start)}`,
+            );
+            await s.writeln(JSON.stringify({ status: response.status, url }));
+          } catch (e) {
+            consola.warn(`xxx GET ${url} ${elapsed(start)}`, e);
+            await s.writeln(
+              JSON.stringify({
+                status: 0,
+                url,
+                error: e instanceof Error ? e.message : String(e),
+              }),
+            );
+          }
+        }),
+      );
     });
   })
   .get(


### PR DESCRIPTION
**Problem**

Fetching all IdP URLs in parallel and waiting for every response before replying means the client waits for the slowest endpoint before seeing any data.

**Proposal**

Switch to NDJSON streaming via `hono/streaming` so each URL result is written to the response as its fetch settles, giving the client incremental feedback without waiting for the full batch.