### PR TITLE
🐛 producer: fix reply stealing between concurrent instances

### DIFF
--- a/examples/idp_cascading_failures/compose.yaml
+++ b/examples/idp_cascading_failures/compose.yaml
@@ -58,7 +58,6 @@ services:
       - AMQP_URL=amqp://guest:guest@rabbitmq:5672
       - IDP_URLS=["http://auth.kraken.tyranids","http://auth.leviathan.tyranids","http://auth.behemoth.tyranids"]
       - QUEUE_PRODUCER_NAME=monitoring-producer
-      - QUEUE_CONSUMER_NAME=monitoring-consumer
       - HTTP_TIMEOUT=100
     depends_on:
       rabbitmq:
@@ -91,7 +90,6 @@ services:
     environment:
       - AMQP_URL=amqp://guest:guest@rabbitmq:5672
       - QUEUE_PRODUCER_NAME=monitoring-producer
-      - QUEUE_CONSUMER_NAME=monitoring-consumer
       - MAP_FI_NAMES_TO_URL={"kraken":"http://auth.kraken.tyranids","leviathan":"http://auth.leviathan.tyranids","behemoth":"http://auth.behemoth.tyranids"}
       - HTTP_TIMEOUT=100
     depends_on:

--- a/examples/idp_error_handling/compose.yaml
+++ b/examples/idp_error_handling/compose.yaml
@@ -58,7 +58,6 @@ services:
       - AMQP_URL=amqp://guest:guest@rabbitmq:5672
       - IDP_URLS=["http://auth.fenris.spacewolves","http://auth.prospero.thousandsons","http://auth.sorcerers.thousandsons"]
       - QUEUE_PRODUCER_NAME=monitoring-producer
-      - QUEUE_CONSUMER_NAME=monitoring-consumer
     depends_on:
       rabbitmq:
         condition: service_healthy
@@ -90,7 +89,6 @@ services:
     environment:
       - AMQP_URL=amqp://guest:guest@rabbitmq:5672
       - QUEUE_PRODUCER_NAME=monitoring-producer
-      - QUEUE_CONSUMER_NAME=monitoring-consumer
       - MAP_FI_NAMES_TO_URL={"fenris":"http://auth.fenris.spacewolves","prospero":"http://auth.prospero.thousandsons","sorcerers":"http://auth.sorcerers.thousandsons"}
     depends_on:
       rabbitmq:

--- a/examples/idp_health_check_rpc/compose.yaml
+++ b/examples/idp_health_check_rpc/compose.yaml
@@ -44,7 +44,6 @@ services:
       - AMQP_URL=amqp://guest:guest@rabbitmq:5672
       - IDP_URLS=["http://auth.rock.darkangels","http://auth.caliban.darkangels"]
       - QUEUE_PRODUCER_NAME=monitoring-producer
-      - QUEUE_CONSUMER_NAME=monitoring-consumer
     depends_on:
       rabbitmq:
         condition: service_healthy
@@ -74,7 +73,6 @@ services:
     environment:
       - AMQP_URL=amqp://guest:guest@rabbitmq:5672
       - QUEUE_PRODUCER_NAME=monitoring-producer
-      - QUEUE_CONSUMER_NAME=monitoring-consumer
       - MAP_FI_NAMES_TO_URL={"rock":"http://auth.rock.darkangels","caliban":"http://auth.caliban.darkangels","inner-circle":"http://auth.rock.darkangels","fallen-angels":"http://auth.caliban.darkangels"}
     depends_on:
       rabbitmq:

--- a/examples/idp_multi_producer_isolation/auth.asaheim.space-wolves.conf
+++ b/examples/idp_multi_producer_isolation/auth.asaheim.space-wolves.conf
@@ -1,0 +1,15 @@
+server {
+    listen 80;
+    server_name auth.asaheim.space-wolves;
+
+    location /health {
+        access_log off;
+        return 200 "healthy\n";
+        add_header Content-Type text/plain;
+    }
+
+    location / {
+        return 200 "The Fang stands eternal. Asaheim authentication holds firm.";
+        add_header Content-Type text/plain;
+    }
+}

--- a/examples/idp_multi_producer_isolation/auth.fenris.space-wolves.conf
+++ b/examples/idp_multi_producer_isolation/auth.fenris.space-wolves.conf
@@ -1,0 +1,15 @@
+server {
+    listen 80;
+    server_name auth.fenris.space-wolves;
+
+    location /health {
+        access_log off;
+        return 200 "healthy\n";
+        add_header Content-Type text/plain;
+    }
+
+    location / {
+        return 200 "For Russ and the Allfather! Fenris authentication endures.";
+        add_header Content-Type text/plain;
+    }
+}

--- a/examples/idp_multi_producer_isolation/compose.yaml
+++ b/examples/idp_multi_producer_isolation/compose.yaml
@@ -3,17 +3,15 @@ services:
     image: rabbitmq:3-management-alpine
     healthcheck:
       test: ["CMD", "rabbitmq-diagnostics", "ping"]
-      interval: 1s
+      interval: 500ms
       timeout: 1s
-      retries: 5
-    networks:
-      - default
-      - fortress-network
+      retries: 10
+      start_period: 2s
 
-  auth.olympia.ironwarriors:
+  auth.fenris.space-wolves:
     image: nginx:alpine
     volumes:
-      - ./auth.olympia.ironwarriors.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./auth.fenris.space-wolves.conf:/etc/nginx/conf.d/default.conf:ro
     healthcheck:
       test:
         [
@@ -24,10 +22,10 @@ services:
       timeout: 1s
       retries: 5
 
-  auth.medrengard.ironwarriors:
+  auth.asaheim.space-wolves:
     image: nginx:alpine
     volumes:
-      - ./auth.medrengard.ironwarriors.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./auth.asaheim.space-wolves.conf:/etc/nginx/conf.d/default.conf:ro
     healthcheck:
       test:
         [
@@ -38,53 +36,51 @@ services:
       timeout: 1s
       retries: 5
 
-  auth.phalanx.imperialfists:
-    image: nginx:alpine
-    volumes:
-      - ./auth.phalanx.imperialfists.conf:/etc/nginx/conf.d/default.conf:ro
-    healthcheck:
-      test:
-        [
-          "CMD-SHELL",
-          "wget --no-verbose --tries=1 --spider http://127.0.0.1/health || exit 1",
-        ]
-      interval: 1s
-      timeout: 1s
-      retries: 5
-    networks:
-      - fortress-network
-
-  auth.inwit.imperialfists:
-    image: nginx:alpine
-    volumes:
-      - ./auth.inwit.imperialfists.conf:/etc/nginx/conf.d/default.conf:ro
-    healthcheck:
-      test:
-        [
-          "CMD-SHELL",
-          "wget --no-verbose --tries=1 --spider http://127.0.0.1/health || exit 1",
-        ]
-      interval: 1s
-      timeout: 1s
-      retries: 5
-    networks:
-      - fortress-network
-
-  producer:
+  producer_alpha:
     build:
       context: ../..
       dockerfile: Dockerfile
       target: producer
     environment:
       - AMQP_URL=amqp://guest:guest@rabbitmq:5672
-      - IDP_URLS=["http://auth.olympia.ironwarriors","http://auth.medrengard.ironwarriors"]
+      - IDP_URLS=["http://auth.fenris.space-wolves","http://auth.asaheim.space-wolves"]
       - QUEUE_PRODUCER_NAME=monitoring-producer
     depends_on:
       rabbitmq:
         condition: service_healthy
-      auth.olympia.ironwarriors:
+      auth.fenris.space-wolves:
         condition: service_healthy
-      auth.medrengard.ironwarriors:
+      auth.asaheim.space-wolves:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "wget",
+          "--no-verbose",
+          "--tries=1",
+          "--spider",
+          "http://127.0.0.1/",
+        ]
+      interval: 1s
+      timeout: 1s
+      retries: 5
+
+  producer_bravo:
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+      target: producer
+    environment:
+      - AMQP_URL=amqp://guest:guest@rabbitmq:5672
+      - IDP_URLS=["http://auth.fenris.space-wolves","http://auth.asaheim.space-wolves"]
+      - QUEUE_PRODUCER_NAME=monitoring-producer
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+      auth.fenris.space-wolves:
+        condition: service_healthy
+      auth.asaheim.space-wolves:
         condition: service_healthy
     healthcheck:
       test:
@@ -108,13 +104,13 @@ services:
     environment:
       - AMQP_URL=amqp://guest:guest@rabbitmq:5672
       - QUEUE_PRODUCER_NAME=monitoring-producer
-      - MAP_FI_NAMES_TO_URL={"olympia":"http://auth.phalanx.imperialfists","medrengard":"http://auth.inwit.imperialfists"}
+      - MAP_FI_NAMES_TO_URL={"fenris":"http://auth.fenris.space-wolves","asaheim":"http://auth.asaheim.space-wolves"}
     depends_on:
       rabbitmq:
         condition: service_healthy
-      auth.phalanx.imperialfists:
+      auth.fenris.space-wolves:
         condition: service_healthy
-      auth.inwit.imperialfists:
+      auth.asaheim.space-wolves:
         condition: service_healthy
     healthcheck:
       test:
@@ -130,41 +126,14 @@ services:
       timeout: 3s
       retries: 5
       start_period: 10s
-    networks:
-      - fortress-network
-
-  proxy:
-    image: nginx:alpine
-    volumes:
-      - ./proxy.conf:/etc/nginx/conf.d/default.conf:ro
-    ports:
-      - "8080:80"
-    depends_on:
-      producer:
-        condition: service_healthy
-    healthcheck:
-      test:
-        [
-          "CMD-SHELL",
-          "wget --no-verbose --tries=1 --spider http://127.0.0.1/ || exit 1",
-        ]
-      interval: 1s
-      timeout: 1s
-      retries: 5
 
   test_runner:
     image: curlimages/curl:latest
     depends_on:
       - rabbitmq
-      - auth.olympia.ironwarriors
-      - auth.medrengard.ironwarriors
-      - auth.phalanx.imperialfists
-      - auth.inwit.imperialfists
-      - producer
+      - auth.fenris.space-wolves
+      - auth.asaheim.space-wolves
+      - producer_alpha
+      - producer_bravo
       - consumer
-      - proxy
     entrypoint: ["sleep", "infinity"]
-
-networks:
-  fortress-network:
-    driver: bridge

--- a/examples/idp_multi_producer_isolation/integration.test.ts
+++ b/examples/idp_multi_producer_isolation/integration.test.ts
@@ -1,0 +1,102 @@
+import { createDockerEnv } from "#testing/docker";
+import { describe, expect, test } from "bun:test";
+
+describe("IDP Multi-Producer Isolation: Direct Reply-to prevents reply stealing", () => {
+  const env = createDockerEnv(import.meta.dir);
+
+  test.serial(
+    "🚀 Setup: Start Docker services with two producer instances",
+    async () => {
+      await env.start({ build: true, quiet: true });
+    },
+    120_000,
+  );
+
+  test.serial("📨 Consumer: Loaded Space Wolves configuration", async () => {
+    const consumerLogs = await env.getServiceLogs("consumer");
+    expect(consumerLogs).toContain("Consumer started successfully!");
+    expect(consumerLogs).toContain("fenris");
+    expect(consumerLogs).toContain("asaheim");
+  });
+
+  test.serial("🐺 Producer Alpha: Connected to RabbitMQ", async () => {
+    const logs = await env.getServiceLogs("producer_alpha");
+    expect(logs).toContain("Connected to RabbitMQ");
+    expect(logs).toContain('Asserting queue "monitoring-producer"');
+  });
+
+  test.serial("🐺 Producer Bravo: Connected to RabbitMQ", async () => {
+    const logs = await env.getServiceLogs("producer_bravo");
+    expect(logs).toContain("Connected to RabbitMQ");
+    expect(logs).toContain('Asserting queue "monitoring-producer"');
+  });
+
+  test.serial(
+    "⚔️ GET /idp/fenris - Alpha RPC returns correct response",
+    async () => {
+      const result = await env.execInService(
+        "test_runner",
+        "curl -s -o /dev/null -w '%{http_code}' http://producer_alpha/idp/fenris",
+      );
+      expect(result.output).toBe("'200'");
+    },
+  );
+
+  test.serial(
+    "⚔️ GET /idp/asaheim - Bravo RPC returns correct response",
+    async () => {
+      const result = await env.execInService(
+        "test_runner",
+        "curl -s -o /dev/null -w '%{http_code}' http://producer_bravo/idp/asaheim",
+      );
+      expect(result.output).toBe("'200'");
+    },
+  );
+
+  test.serial(
+    "🔀 Concurrent RPC across both producers — no reply stealing (Direct Reply-to)",
+    async () => {
+      const requests = Array.from({ length: 10 }, (_, i) => {
+        const producer = i % 2 === 0 ? "producer_alpha" : "producer_bravo";
+        const idp = i % 2 === 0 ? "fenris" : "asaheim";
+        return env.execInService(
+          "test_runner",
+          `curl -s -o /dev/null -w '%{http_code}' http://${producer}/idp/${idp}`,
+        );
+      });
+
+      const results = await Promise.all(requests);
+
+      for (const result of results) {
+        expect(result.output).toBe("'200'");
+      }
+    },
+    30_000,
+  );
+
+  test.serial(
+    "❌ GET /idp/unknown - Both producers return 404 for unknown IDP",
+    async () => {
+      const [alpha, bravo] = await Promise.all([
+        env.execInService(
+          "test_runner",
+          "curl -s -o /dev/null -w '%{http_code}' http://producer_alpha/idp/unknown",
+        ),
+        env.execInService(
+          "test_runner",
+          "curl -s -o /dev/null -w '%{http_code}' http://producer_bravo/idp/unknown",
+        ),
+      ]);
+      expect(alpha.output).toBe("'404'");
+      expect(bravo.output).toBe("'404'");
+    },
+  );
+
+  test.serial(
+    "🧹 Cleanup: Stop all services",
+    async () => {
+      await env[Symbol.asyncDispose]();
+    },
+    30_000,
+  );
+});

--- a/examples/idp_resilience/compose.yaml
+++ b/examples/idp_resilience/compose.yaml
@@ -45,7 +45,6 @@ services:
       - AMQP_URL=amqp://guest:guest@rabbitmq:5672
       - IDP_URLS=["http://auth.macragge.ultramarines","http://auth.calth.ultramarines"]
       - QUEUE_PRODUCER_NAME=monitoring-producer
-      - QUEUE_CONSUMER_NAME=monitoring-consumer
     depends_on:
       rabbitmq:
         condition: service_healthy
@@ -75,7 +74,6 @@ services:
     environment:
       - AMQP_URL=amqp://guest:guest@rabbitmq:5672
       - QUEUE_PRODUCER_NAME=monitoring-producer
-      - QUEUE_CONSUMER_NAME=monitoring-consumer
       - MAP_FI_NAMES_TO_URL={"macragge":"http://auth.macragge.ultramarines","calth":"http://auth.calth.ultramarines"}
     depends_on:
       rabbitmq:

--- a/idp-status-monitoring-producer/src/config/schema.ts
+++ b/idp-status-monitoring-producer/src/config/schema.ts
@@ -32,7 +32,6 @@ export const ConfigSchema = z.object({
   IDP_URLS: parseJsonArray,
   LOG_LEVEL: z.coerce.number().default(3),
   PORT: z.coerce.number().default(80),
-  QUEUE_CONSUMER_NAME: z.string().default("monitoring-consumer"),
   QUEUE_PRODUCER_NAME: z.string().default("monitoring-producer"),
 });
 

--- a/idp-status-monitoring-producer/src/rpc/index.ts
+++ b/idp-status-monitoring-producer/src/rpc/index.ts
@@ -31,50 +31,38 @@ export function setupRpcProducer(
   connection: AmqpConnectionManager,
   config: Config,
 ) {
-  const { QUEUE_CONSUMER_NAME, QUEUE_PRODUCER_NAME } = config;
+  const { QUEUE_PRODUCER_NAME } = config;
 
   const channel_wrapper = connection.createChannel({
     setup: (channel: Channel) => {
       consola.info(`Asserting queue "${QUEUE_PRODUCER_NAME}"`);
-      consola.info(`Asserting queue "${QUEUE_CONSUMER_NAME}"`);
-
-      return Promise.all([
-        channel.assertQueue(QUEUE_PRODUCER_NAME, { durable: true }),
-        channel.assertQueue(QUEUE_CONSUMER_NAME, { durable: true }),
-      ]);
+      return channel.assertQueue(QUEUE_PRODUCER_NAME, { durable: true });
     },
   });
 
   channel_wrapper.setMaxListeners(0);
-  channel_wrapper.consume(QUEUE_CONSUMER_NAME, (message) => {
-    try {
-      // Validate message structure
+  channel_wrapper.consume(
+    "amq.rabbitmq.reply-to",
+    (message) => {
       if (!message?.content || !message?.properties) {
         consola.error(
           "Malformed message received: missing content or properties",
         );
-        channel_wrapper.nack(message, false, false);
         return;
       }
 
       const { correlationId } = message.properties;
       if (!correlationId) {
         consola.error("Message missing required correlationId property");
-        channel_wrapper.nack(message, false, false);
         return;
       }
 
       const content = message.content.toString("utf8");
       consola.debug(`Received message: ${correlationId} - ${content}`);
-
       channel_wrapper.emit(correlationId, content);
-      channel_wrapper.ack(message);
-    } catch (err) {
-      consola.error("Error processing message:", err);
-      // Don't requeue on processing errors
-      channel_wrapper.nack(message, false, false);
-    }
-  });
+    },
+    { noAck: true },
+  );
 
   return channel_wrapper;
 }

--- a/idp-status-monitoring-producer/src/server/router.ts
+++ b/idp-status-monitoring-producer/src/server/router.ts
@@ -94,7 +94,7 @@ export const router = new Hono<ServerContext>()
     async ({ env, req, var: { channelWrapper } }) => {
       const { name } = req.valid("param");
 
-      const { QUEUE_CONSUMER_NAME, QUEUE_PRODUCER_NAME, HTTP_TIMEOUT } = env;
+      const { QUEUE_PRODUCER_NAME, HTTP_TIMEOUT } = env;
       const correlationId = uuid();
 
       const { promise, resolve } = Promise.withResolvers<Response>();
@@ -115,7 +115,7 @@ export const router = new Hono<ServerContext>()
       channelWrapper.sendToQueue(QUEUE_PRODUCER_NAME, name, {
         correlationId,
         expiration: HTTP_TIMEOUT,
-        replyTo: QUEUE_CONSUMER_NAME,
+        replyTo: "amq.rabbitmq.reply-to",
         persistent: false,
       });
 


### PR DESCRIPTION
**Problem**

When multiple producer instances run simultaneously, ~50% of RPC
requests to /idp/:name timeout (503). Both instances consume from
the same shared QUEUE_CONSUMER_NAME queue, so either instance can
pick up a reply meant for the other. The correct producer then waits
indefinitely until HTTP_TIMEOUT.

**Proposal**

Switch to AMQP Direct Reply-to (amq.rabbitmq.reply-to): each producer
connection gets an implicit private reply channel. The replyTo header
in outbound messages now points to this pseudo-queue instead of the
shared named queue. RabbitMQ routes replies back to the originating
connection, making cross-instance interception impossible.

Removes QUEUE_CONSUMER_NAME from the producer config entirely.
Adds idp_multi_producer_isolation integration test that reproduces
the race with two concurrent producers and asserts all 10 parallel
requests return 200.

Ref: https://www.rabbitmq.com/docs/direct-reply-to
- Consumer must subscribe to amq.rabbitmq.reply-to in no-ack mode
- Consume and publish must share the same channel (same channel_wrapper)
- At-most-once delivery — replies dropped on disconnect (timeout 503 handles this)